### PR TITLE
fix circular dependency

### DIFF
--- a/cvssv3_test.go
+++ b/cvssv3_test.go
@@ -1,7 +1,6 @@
 package cvssv3
 
 import (
-	"cvssv3"
 	"fmt"
 	"testing"
 )
@@ -53,7 +52,7 @@ func TestBaseScore(t *testing.T) {
 		"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H": 9.6,
 	}
 	for vs,expected := range d {
-		m, err := cvssv3.ParseVector(vs)
+		m, err := ParseVector(vs)
 		if err == nil {
 			actual := m.BaseScore()
 			fmt.Printf("%s, expected = %4.1f, actual = %4.1f\n", vs, expected, actual)


### PR DESCRIPTION
Summary:
 [cvssv3_test](https://sourcegraph.com/github.com/bunji2/cvssv3/-/blob/cvssv3_test.go#L4) has circular import, causing go1.13 to alert for this test
```
deps imports
	github.com/bunji2/cvssv3 tested by
	github.com/bunji2/cvssv3.test imports
	cvssv3: malformed module path "cvssv3": missing dot in first path element
```

Test Plan:
go import forked version successfully
go test ./... successfully
go build ./... successfully